### PR TITLE
Adjust projects grid content

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -3000,6 +3000,8 @@ h3.project-sidebar-header {
   position: relative;
   width: 25.5rem;
   height: 25.5rem;
+  max-width: 100%;
+  max-height: 44vw;
   overflow: hidden;
   padding: 2rem;
   border: 2px solid #51a4a1;
@@ -3018,7 +3020,7 @@ h3.project-sidebar-header {
   right: 0;
   margin: auto;
   transition: 0.5s;
-  padding: 1rem;
+  padding: 1rem min(1vw, 1rem);
   border: solid 2px #03777e;
   border-radius: 3%;
   -webkit-box-shadow: inset 1px 1px 10px #af0b13, inset -1px -1px 10px #af0b13;
@@ -3032,7 +3034,7 @@ h3.project-sidebar-header {
 
 .project-info h3 {
   color: #fff;
-  font-size: 2rem;
+  font-size: min(3.5vw, 2rem);
   margin-bottom: 0.5rem;
 }
 
@@ -3147,7 +3149,7 @@ li.npp-content {
 .icon::before {
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
-  display: inline-block; 
+  display: inline-block;
   font-style: normal;
   font-variant: normal;
   text-rendering: auto;
@@ -3285,15 +3287,15 @@ h3.faq-title {
   text-underline-offset: 0.3em;
 }
 
-div.faq a>i.fas,
-div.faq a>i.fab,
-div.faq a>i.far {
+div.faq a > i.fas,
+div.faq a > i.fab,
+div.faq a > i.far {
   color: #f2454e;
 }
 
-div.faq a:hover>i.fas,
-div.faq a:hover>i.fab,
-div.faq a:hover>i.far {
+div.faq a:hover > i.fas,
+div.faq a:hover > i.fab,
+div.faq a:hover > i.far {
   color: #fdd14a;
   transition: all 0.2s ease-out 0s;
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -3287,15 +3287,15 @@ h3.faq-title {
   text-underline-offset: 0.3em;
 }
 
-div.faq a > i.fas,
-div.faq a > i.fab,
-div.faq a > i.far {
+div.faq a>i.fas,
+div.faq a>i.fab,
+div.faq a>i.far {
   color: #f2454e;
 }
 
-div.faq a:hover > i.fas,
-div.faq a:hover > i.fab,
-div.faq a:hover > i.far {
+div.faq a:hover>i.fas,
+div.faq a:hover>i.fab,
+div.faq a:hover>i.far {
   color: #fdd14a;
   transition: all 0.2s ease-out 0s;
 }


### PR DESCRIPTION
This PR replaces PR #26. It includes some CSS changes to the projects grid so the content works better on all screen sizes without removing bootstrap classes. This closes #22 

I checked the texts that show up on hover using a variable font-size and horizontal padding to make sure they fit the available space in really small devices.

I ended up leaving the 2 columns for the smaller viewport because the smallest breakpoint included in bootstrap was too big to use if for a 1 column grid.

Some screenshots:
![localhost_4000_our-work_impact(iPhone 5_SE) (1)](https://user-images.githubusercontent.com/188464/132611113-580fa9f6-b5f3-433d-bc07-33eaa0aad7bd.png)
![localhost_4000_our-work_impact(iPhone X) (1)](https://user-images.githubusercontent.com/188464/132611122-d641a57b-dee6-43d9-acda-f7e59e2ad7ca.png)
![localhost_4000_our-work_impact(iPad)](https://user-images.githubusercontent.com/188464/132611136-cf01753d-bded-4324-857d-6c214687bc4f.png)
![localhost_4000_our-work_impact](https://user-images.githubusercontent.com/188464/132611140-04a1cc56-620b-4145-8a00-9323ebe28e60.png)
