### PR TITLE
Update the responsiveness of the team member photo and social media

### DIFF
--- a/_includes/about_us/team_member.html
+++ b/_includes/about_us/team_member.html
@@ -52,7 +52,7 @@
             <i class="fab fa-{{ platform.icon }}"></i>
             &nbsp;&nbsp;{{ platform.handle }}
           </a>
-          &nbsp;|&nbsp; {% endif %} {% endfor %}
+          <span>&nbsp;|&nbsp;</span> {% endif %} {% endfor %}
           <!--          <a href="mailto:{{ page.email }}"><i class="fas fa-envelope"></i>&nbsp;&nbsp;{{ page.email }}</a>-->
         </h5>
       </div>

--- a/_includes/about_us/team_member.html
+++ b/_includes/about_us/team_member.html
@@ -52,7 +52,7 @@
             <i class="fab fa-{{ platform.icon }}"></i>
             &nbsp;&nbsp;{{ platform.handle }}
           </a>
-          <span>&nbsp;|&nbsp;</span> {% endif %} {% endfor %}
+          <span class="slash">&nbsp;|&nbsp;</span> {% endif %} {% endfor %}
           <!--          <a href="mailto:{{ page.email }}"><i class="fas fa-envelope"></i>&nbsp;&nbsp;{{ page.email }}</a>-->
         </h5>
       </div>

--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -281,6 +281,9 @@
     right: 0;
     text-align: center;
   }
+  .slash {
+    display: none;
+  }
 }
 
 /* SM Small Device :550px. */

--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -130,11 +130,6 @@
   .sticky {
     position: static;
   }
-  h3.team-member-position {
-    position: absolute;
-    top: 0;
-    left: 0;
-  }
 }
 
 /* Extra small Device. */
@@ -276,6 +271,15 @@
   }
   .bio-box {
     max-width: 100%;
+  }
+  h3.team-member-position {
+    position: absolute;
+    top: -36px;
+    margin-left: auto;
+    margin-right: auto;
+    left: 0;
+    right: 0;
+    text-align: center;
   }
 }
 

--- a/assets/css/responsive.css
+++ b/assets/css/responsive.css
@@ -130,10 +130,20 @@
   .sticky {
     position: static;
   }
+  h3.team-member-position {
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
 }
 
 /* Extra small Device. */
 @media (max-width: 767px) {
+  h5.team-member-contacts {
+    display: flex;
+    flex-direction: column;
+    justify-content: left;
+  }
   .header-top.blue-bg {
     padding: 10px 0;
   }
@@ -263,6 +273,9 @@
   }
   .title-header > h2 {
     font-size: 3.8rem;
+  }
+  .bio-box {
+    max-width: 100%;
   }
 }
 


### PR DESCRIPTION
This PR fixes issue: #20 

I consulted with @meg-gutshall, and made the photo full width in smaller devices. I also moved the title to be above the photo and centered under the red line. Also, we are hiding the slash between the social media links on small devices and moving them to separate lines. 

![127 0 0 1_4000_our-team_sean-marcia(iPhone X) (3)](https://user-images.githubusercontent.com/28625558/142131002-b37ba48d-594d-4df1-b99a-1f0a81bf4ef7.png)
![Screen Shot 2021-11-16 at 10 41 11 PM](https://user-images.githubusercontent.com/28625558/142131024-05ca22e5-730f-4342-b17a-a8174e61c490.png)
![Screen Shot 2021-11-16 at 10 41 18 PM](https://user-images.githubusercontent.com/28625558/142131026-73a83261-a7aa-446b-b9f2-a2eed73a1aae.png)
