### PR TITLE
Carousel controls overflow in home page

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -223,19 +223,24 @@
     ],
     responsive: {
       0: {
-        items: 2
+        items: 2,
+        nav: false
       },
       320: {
-        items: 2
+        items: 2,
+        nav: false
       },
       480: {
-        items: 3
+        items: 3,
+        nav: false
       },
       767: {
-        items: 4
+        items: 4,
+        nav: false
       },
       991: {
-        items: 4
+        items: 4,
+        nav: false
       },
       1000: {
         items: 4


### PR DESCRIPTION
Issue: The controls of the carousel at the bottom of the page are placed outside the container, adding extra width to the document and adding that extra scroll to the right side.
Some options to fix this:
1. hide the controls for the resolution when they start to not fit into the width
2. or, resize the container of the carousel so the controls are still inside the viewport
I think option 1 is simpler since on those devices the user can move the carousel by swiping with a touch.

- This PR solves the issue following the first suggestion. It was found that for devices smaller than ~ 850px, the navigation controls added extra width.

Closes #19 