### PR TITLE
Fix link to stocks-in-the-future

### DIFF
--- a/_includes/events/faq.html
+++ b/_includes/events/faq.html
@@ -228,7 +228,7 @@
             <a href="https://github.com/rubyforgood/pet-rescue" rel="noopener noreferrer" target="_blank">Pet Rescue</a> supports the <a href="https://www.bajapetrescue.com/" rel="noopener noreferrer" target="_blank">Baja Pet Rescue</a> with more rescues coming
             </li>
           <li class="bulleted indented">
-            <a href="https://github.com/rubyforgood/stocksinthefuture" rel="noopener noreferrer" target="_blank">Stocks In the Future</a> teaches financial literacy to youths in Baltimore
+            <a href="https://github.com/rubyforgood/stocks-in-the-future" rel="noopener noreferrer" target="_blank">Stocks In the Future</a> teaches financial literacy to youths in Baltimore
           </li>
           <li class="bulleted indented">
             <a href="https://github.com/rubyforgood/flaredown" rel="noopener noreferrer" target="_blank">Flaredown</a> helps individuals with chronic conditions track symptoms over time, and learn how to control them


### PR DESCRIPTION
The repo name has dashes in it https://github.com/rubyforgood/stocks-in-the-future