### PR TITLE
Add skip links for improved keyboard navigation accessibility

### DIFF
--- a/_includes/mixins/main_header.html
+++ b/_includes/mixins/main_header.html
@@ -1,5 +1,6 @@
 <header>
   <div id="sticky-header" class="menu-area">
+    <a href="#main-content">Skip to Content</a>
     <div class="container">{% include mixins/navbar.html %}</div>
   </div>
 </header>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,4 +3,4 @@ layout: default
 ---
 
 {% include mixins/main_header.html %}
-<main>{{content}}</main>
+<main id="main-content" tabindex="-1">{{content}}</main>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -34,6 +34,28 @@ Version: 1.0
 
 /* ---------------- 0. Custom Meg Styling ---------------- */
 
+[href="#main-content"] {
+  background: #03777e;
+  border-radius: 0 0 0.5rem;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 30%);
+  color: #fff;
+  font-size: 1.6rem;
+  font-weight: bold;
+  padding: 1rem 2rem;
+  text-decoration: none;
+}
+
+/* Hide skip link when it's not focused */
+[href="#main-content"]:not(:focus) {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+
 /* Set font for responsiveness
 ------------------------------
 Most browsers set their default font size to 1.6rem, so if we set ours at 62.5% of that it will come out to 10px. From there, it's a lot easier to calculate rem sizing. Plus if someone changes their default browser settings, our site is coded to respond to it automatically.


### PR DESCRIPTION
## Summary
Implements skip-to-content functionality to help keyboard and screen reader users bypass navigation links and jump directly to the main content.

## Changes
- Added "Skip to Content" link at the top of each page (before navbar)
- Link is visually hidden by default but appears when focused via keyboard (Tab)
- Styled with site brand colors (#03777e teal) for consistency
- Added `id="main-content"` and `tabindex="-1"` to main element for proper focus management
- Uses modern `clip-path` technique for accessible element hiding

## Testing
To test:
1. Visit any page on the site
2. Press `Tab` - the "Skip to Content" link should appear at the top
3. Press `Enter` - should jump to main content
4. Press `Tab` again without activating - should continue to navigation items

## Screenshot
![output](https://github.com/user-attachments/assets/509eec43-3990-455b-8591-38b9c0acbfcc)


## Notes
The skip link styling uses the site's primary teal color. Let me know if you'd prefer different styling or positioning!

Fixes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)